### PR TITLE
--module needs to be specified with terraform output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In outputs there is **terraform_config** with generated terraform configuration 
 You can paste it directly into new terraform code where you want to start using multiple workspaces:
 
 ```
-terraform output terraform_config > tfstate.tf
+terraform output --module=config-state terraform_config > tfstate.tf
 ```
 
 Then follow [documentation](https://www.terraform.io/docs/state/workspaces.html) on how to use workspaces and leverage it when dealing with multiple environments and many people working with code.


### PR DESCRIPTION
Otherwise this happens:

```
$ terraform output terraform_config
The state file either has no outputs defined, or all the defined
outputs are empty. Please define an output in your configuration
with the `output` keyword and run `terraform refresh` for it to
become available. If you are using interpolation, please verify
the interpolated value is not empty. You can use the
`terraform console` command to assist.
```